### PR TITLE
added a default node selector to run job on ocp masters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ openshift_ldapsync_namespace: openshift-infra
 openshift_ldapsync_configmap_name: ldapsync-config
 openshift_ldapsync_schedule: "*/60 * * * *"
 openshift_config_dir: /etc/origin/master
+openshift_ldapsync_nodeselector: {"node-role.kubernetes.io/master":"true"}

--- a/files/ldapsync/ldapsync-job.yaml.j2
+++ b/files/ldapsync/ldapsync-job.yaml.j2
@@ -26,4 +26,10 @@ spec:
           - name: ldapconfig-volume
             configMap:
               name: {{ openshift_ldapsync_configmap_name }}
-          restartPolicy: OnFailure  
+          restartPolicy: OnFailure
+{% if openshift_ldapsync_nodeselector is iterable and openshift_ldapsync_nodeselector | length > 0 %}
+          nodeSelector:
+{% for key, value in openshift_ldapsync_nodeselector.items() %}
+            {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Ideally, we would only want to run this job on openshift masters and now that openshift has standardised its node labelling strategy since 3.10 this could be a nice addition. 